### PR TITLE
reference npm version of packages to close #6

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "freeport": "^1.0.3",
     "shell-quote": "^1.4.2",
     "ssh2": "^0.3.4",
-    "strider-runner-core": "git+https://github.com/Strider-CD/strider-runner-core",
-    "strider-simple-runner": "git+https://github.com/Strider-CD/strider-simple-runner#for-docker"
+    "strider-runner-core": "^0.1.4",
+    "strider-simple-runner": "^0.12.1"
   }
 }


### PR DESCRIPTION
@jaredly when you get a chance we must merge this and bump and update the npm copy. I tested it and it looks like everything is working great with the strider-simple-runner and strider-runner-core that are on npm.

until this is done people can't npm install 
