### PR TITLE
allow host dir to volume bindings

### DIFF
--- a/config/config.html
+++ b/config/config.html
@@ -5,6 +5,10 @@
 <input ng-model="config.docker_host" placeholder="Docker remote host (defaults to env var DOCKER_HOST)" class="input-block-level input-xxlarge" type="text">
 <input ng-model="config.image" placeholder="Docker image to use. Default: strider/strider-docker-slave" class="input-block-level input-xxlarge" type="text">
 <input ng-model="config.dns" placeholder="comma separated list of dns servers, default: 8.8.8.8" class="input-block-level input-xxlarge" type="text">
+<p>
+  Use the following to bind host directories to volumes in a docker container:
+</p>
+<input ng-model="config.docker_volumeBinds" placeholder="comma seperated list of bindings e.g.: /some/host/dir:/in_container:rw,/other:/foo:rw, Default: ''" class="input-block-level input-xxlarge" type="text">
 <label class="checkbox">
   <input type="checkbox" ng-model="config.privileged">
   Should the image run in privileged mode? WARNING: Don't run insecure code in privileged mode.

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = {
     port: Number,
     socketPath: String,
     dns: String,
-    docker_host: String
+    docker_host: String,
+    docker_volumeBinds: String
   }
 }

--- a/lib/create-container.js
+++ b/lib/create-container.js
@@ -56,6 +56,7 @@ function create (createOptions, docker, config, done) {
 
       // start, and wait for it to be done
       container.start({
+        Binds: config.docker_volumeBinds,
         Privileged: config.privileged,
         PublishAllPorts: config.publishPorts,
         Dns: config.dns,

--- a/lib/run.js
+++ b/lib/run.js
@@ -28,6 +28,14 @@ module.exports = function (job, provider, plugins, config, next) {
     if (slaveConfig.dns && slaveConfig.dns.length > 6) {
       slaveConfig.dns   = slaveConfig.dns.split(",")
     }
+    if (slaveConfig.docker_volumeBinds && slaveConfig.docker_volumeBinds.indexOf(',') > -1) {
+      slaveConfig.docker_volumeBinds = slaveConfig
+                                                 .docker_volumeBinds
+                                                 .split(",")
+                                                 .map(function (volBinding) {
+                                                   return volBinding.trim();
+                                                 });
+    }
     config.io.emit('job.status.command.comment', job._id, {
       comment: 'Creating docker container from ' + slaveConfig.image,
       plugin: 'docker',


### PR DESCRIPTION
This allows for binding host directories (on the system on which the docker daemon runs) to a directory or volume inside a docker container.

This is useful when data needs to be shared between containers (e.g. compiler caches, config data etc.)