### PR TITLE
Add Docker link support

### DIFF
--- a/config/config.html
+++ b/config/config.html
@@ -8,7 +8,11 @@
 <p>
   Use the following to bind host directories to volumes in a docker container:
 </p>
-<input ng-model="config.docker_volumeBinds" placeholder="comma seperated list of bindings e.g.: /some/host/dir:/in_container:rw,/other:/foo:rw, Default: ''" class="input-block-level input-xxlarge" type="text">
+<input ng-model="config.docker_volumeBinds" placeholder="comma separated list of bindings e.g.: /some/host/dir:/in_container:rw,/other:/foo:rw, Default: ''" class="input-block-level input-xxlarge" type="text">
+<p>
+  Link running docker containers into the test container:
+</p>
+<input ng-model="config.docker_links" placeholder="comma separated list of links e.g.: mongo:db,redis,/mysql_1:db2, Default: ''" class="input-block-level input-xxlarge" type="text">
 <label class="checkbox">
   <input type="checkbox" ng-model="config.privileged">
   Should the image run in privileged mode? WARNING: Don't run insecure code in privileged mode.

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = {
     socketPath: String,
     dns: String,
     docker_host: String,
-    docker_volumeBinds: String
+    docker_volumeBinds: String,
+    docker_links: String
   }
 }

--- a/lib/create-container.js
+++ b/lib/create-container.js
@@ -5,6 +5,7 @@ var debug = require('debug')('strider-docker-runner:create-container')
 var async = require('async');
 var demuxer = require('./demuxer')
 var inspect = require('util').inspect;
+var resolveLinks = require('./links').resolveLinks;
 
 function isImageLocally(docker, image, done) {
   var withoutTag = image.split(':')[0];
@@ -65,22 +66,26 @@ function create (createOptions, docker, config, done) {
       if (err) return done(err)
       if (!streamc) return done(new Error("Failed to attach container stream"))
 
-      // start, and wait for it to be done
-      container.start({
-        Binds: config.docker_volumeBinds,
-        Privileged: config.privileged,
-        PublishAllPorts: config.publishPorts,
-        Dns: config.dns,
-      }, function(err, data) {
-        if(err) return done(new Error(err))
-        container.wait(function(err, data) {
-          debug('done with the container', err, data)
-          container.stop(function (err, _) {
-            debug('Stopped the container!')
-          })
-        })
-        done(err, spawn.bind(null, streamc), kill)
-      })
+      resolveLinks(docker, config.docker_links, function (err, links) {
+        if (err) return done(err);
+        // start, and wait for it to be done
+        container.start({
+          Binds: config.docker_volumeBinds,
+          Links: links,
+          Privileged: config.privileged,
+          PublishAllPorts: config.publishPorts,
+          Dns: config.dns,
+        }, function(err, data) {
+          if(err) return done(new Error(err))
+          container.wait(function(err, data) {
+            debug('done with the container', err, data)
+            container.stop(function (err, _) {
+              debug('Stopped the container!')
+            });
+          });
+          done(err, spawn.bind(null, streamc), kill)
+        });
+      });
     }
 
     function kill (done) {

--- a/lib/links.js
+++ b/lib/links.js
@@ -1,0 +1,98 @@
+
+var async = require('async');
+var debug = require('debug')('strider-docker-runner:links');
+var linkLabels = ['com.stridercd.link', 'com.docker.compose.service'];
+
+// Parse docker link syntax into sanitized name, alias pair
+// e.g. redis:db  -> [redis, db]
+//      mongo     -> [mongo, mongo]
+//      /db_1     -> [db_1, db_1]
+// Returns undefined on parse failure
+function parseLink (link) {
+  if (typeof link !== 'string') return;
+  var parts = link.split(':');
+  if (parts.length > 2 || !parts[0].length) return;
+  var name = parts[0].replace(/^\//, '').trim();
+  if (!name.length) return;
+  var alias = parts.length === 1 ? name : parts[1].trim();
+  if (!alias.length) return;
+  return [name, alias];
+}
+
+// List all containers matching a label = value filter
+function filterContainers (docker, label, value, done) {
+  var opts = {filters: JSON.stringify({label: [label + '=' + value]})};
+  docker.listContainers(opts, done);
+}
+
+// Find the first label with containers matching value and return the containers
+// Errors are considered a non-match and are never returned.
+// Callback is called with undefined if no labels matched any containers.
+function findLabeledContainers (docker, labels, value, done) {
+  // Hack reduce error to work like find
+  async.reduce(labels, undefined, function (found, label, done) {
+    filterContainers(docker, label, value, function (err, containers) {
+      if (found) return done(found);
+      if (containers && containers.length > 0) {
+        debug('[runner:docker] found containers with label', label);
+        return done(containers);
+      }
+      debug('[runner:docker] no containers with label', label);
+      done();
+    });
+  }, function (containers) {
+    done(undefined, containers);
+  });
+}
+
+// Find the first label with a container matching value and return the container
+// Errors are considered a non-match and are never returned.
+// Callback is called with undefined if no labels matched any container.
+function findLabeledContainer (docker, labels, value, done) {
+  findLabeledContainers(docker, labels, value, function (err, containers) {
+    if (containers && containers.length > 0) {
+      return done(undefined, containers[0]);
+    }
+    done();
+  });
+}
+
+// Resolves strider docker runner links into docker links using names and labels
+// First checks for a container with the given name, then searches for
+// the first container matching a set of predefined labels.
+// Callback called with an error if the link cannot be parsed or no matching
+// container is found.
+function resolveLinks (docker, links, done) {
+  async.map(links, function (link, done) {
+
+    var parsed = parseLink(link);
+    if (!parsed) return done(new Error('Invalid link: ' + link));
+
+    function resolve (name) {
+      var resolved = [name, parsed[1]].join(':');
+      debug('[runner:docker] resolved link', link, resolved);
+      return done(undefined, resolved);
+    }
+
+    // Try to find a container by name (or id)
+    var name = parsed[0];
+    docker.getContainer(name).inspect(function (err, container) {
+      if (!err && container) return resolve(name);
+      debug('[runner:docker] no container with name', name);
+      // Try to find a container by label
+      findLabeledContainer(docker, linkLabels, name, function (err, container) {
+        if (!err && container) return resolve(container.Id);
+        debug('[runner:docker] no container with label', name);
+        done(new Error('No container found for link: ' + link));
+      });
+    });
+  }, done);
+}
+
+module.exports = {
+  parseLink: parseLink,
+  filterContainers: filterContainers,
+  findLabeledContainers: findLabeledContainers,
+  findLabeledContainer: findLabeledContainer,
+  resolveLinks: resolveLinks
+};

--- a/lib/run.js
+++ b/lib/run.js
@@ -36,6 +36,20 @@ module.exports = function (job, provider, plugins, config, next) {
                                                    return volBinding.trim();
                                                  });
     }
+    if (slaveConfig.docker_links) {
+      slaveConfig.docker_links = slaveConfig.docker_links.trim();
+      if (slaveConfig.docker_links.indexOf(',') > -1) {
+        slaveConfig.docker_links = slaveConfig
+                                             .docker_links
+                                             .split(",")
+                                             .map(function (link) {
+                                               return link.trim();
+                                             });
+      } else if (slaveConfig.docker_links) {
+        slaveConfig.docker_links = [slaveConfig.docker_links];
+      }
+    }
+    slaveConfig.docker_links = slaveConfig.docker_links || [];
     config.io.emit('job.status.command.comment', job._id, {
       comment: 'Creating docker container from ' + slaveConfig.image,
       plugin: 'docker',

--- a/test/unit/links_test.js
+++ b/test/unit/links_test.js
@@ -1,0 +1,215 @@
+var expect = require('chai').expect
+  , links = require('../../lib/links')
+
+describe("links#parseLink()", function () {
+  var fn = links.parseLink;
+
+  it('returns undefined for invalid links', function () {
+    expect(fn()).to.be.undefined;
+    expect(fn('')).to.be.undefined;
+    expect(fn(':')).to.be.undefined;
+    expect(fn('a:')).to.be.undefined;
+    expect(fn(':b')).to.be.undefined;
+    expect(fn('a:b:c')).to.be.undefined;
+  });
+
+  it('uses the name as alias when no alias given', function () {
+    expect(fn('abc')).to.deep.equal(['abc', 'abc']);
+  });
+
+  it('splits a name:alias pair', function () {
+    expect(fn('a:b')).to.deep.equal(['a', 'b']);
+  });
+
+  it('strips the leading slash from the name', function () {
+    expect(fn('/a:b')).to.deep.equal(['a', 'b']);
+  });
+});
+
+describe("links#filterContainers()", function () {
+
+  it('calls docker.listContainers with a label/value filter', function (done) {
+    var docker = {
+      listContainers: function (opts, done) {
+        expect(opts).to.deep.equal({filters: '{"label":["a=b"]}'});
+        done();
+      }
+    };
+    links.filterContainers(docker, 'a', 'b', done);
+  });
+});
+
+describe("links#findLabeledContainers()", function () {
+
+  it('swallows errors', function (done) {
+    var docker = {
+      listContainers: function (opts, done) {
+        done(new Error());
+      }
+    };
+    links.findLabeledContainers(docker, ['a'], 'b', done);
+  });
+
+  it('returns undefined if no containers match', function (done) {
+    var docker = {
+      listContainers: function (opts, done) {
+        done(null, []);
+      }
+    };
+    links.findLabeledContainers(docker, ['a'], 'b', function (err, containers) {
+      expect(err).to.be.undefined;
+      expect(containers).to.be.undefined;
+      done();
+    });
+  });
+
+  it('finds the first label with containers matching the value and returns the containers', function (done) {
+    var docker = {
+      listContainers: function (opts, done) {
+        if (opts.filters !== '{"label":["b=v"]}') return done(null, []);
+        done(null, ['a', 'b']);
+      }
+    };
+    links.findLabeledContainers(docker, ['a', 'b', 'c'], 'v', function (err, containers) {
+      expect(err).to.be.undefined;
+      expect(containers).to.deep.equal(['a', 'b']);
+      done();
+    });
+  });
+
+  it('does not ask docker for containers after it finds a match', function (done) {
+    var calls = 0;
+    var docker = {
+      listContainers: function (opts, done) {
+        calls++;
+        done(null, ['a', 'b']);
+      }
+    };
+    links.findLabeledContainers(docker, ['a', 'b', 'c'], 'v', function (err, containers) {
+      expect(err).to.be.undefined;
+      expect(containers).to.deep.equal(['a', 'b']);
+      expect(calls).to.equal(1);
+      done();
+    });
+  });
+});
+
+describe("links#findLabeledContainer()", function () {
+
+  it('returns undefined if no containers match', function (done) {
+    var docker = {
+      listContainers: function (opts, done) {
+        done(null, []);
+      }
+    };
+    links.findLabeledContainer(docker, ['a'], 'b', function (err, container) {
+      expect(err).to.be.undefined;
+      expect(container).to.be.undefined;
+      done();
+    });
+  });
+
+  it('returns the first matching container', function (done) {
+    var docker = {
+      listContainers: function (opts, done) {
+        done(null, ['a', 'b']);
+      }
+    };
+    links.findLabeledContainer(docker, ['a'], 'v', function (err, containers) {
+      expect(err).to.be.undefined;
+      expect(containers).to.equal('a');
+      done();
+    });
+  });
+});
+
+describe("links#resolveLinks()", function () {
+
+  it('returns an error if no containers match a link', function (done) {
+    var docker = {
+      listContainers: function (opts, done) {
+        done(null, []);
+      },
+      getContainer: function (name) {
+        return {
+          inspect: function (done) {
+            return done(new Error());
+          }
+        }
+      }
+    };
+    links.resolveLinks(docker, ['a'], function (err, links) {
+      expect(err).to.be.an.instanceof(Error);
+      done();
+    });
+  });
+
+  it('resolves links by name', function (done) {
+    var docker = {
+      listContainers: function (opts, done) {
+        done(null, []);
+      },
+      getContainer: function (name) {
+        return {
+          inspect: function (done) {
+            return done(null, name);
+          }
+        }
+      }
+    };
+    links.resolveLinks(docker, ['a', 'b'], function (err, links) {
+      expect(err).to.be.undefined;
+      expect(links).to.deep.equal(['a:a', 'b:b']);
+      done();
+    });
+  });
+
+  it('resolves links with the com.stridercd.link label', function (done) {
+    var docker = {
+      listContainers: function (opts, done) {
+        var parts = JSON.parse(opts.filters).label[0].split('=');
+        var label = parts[0];
+        var value = parts[1];
+        if (label === 'com.stridercd.link') return done(null, [{Id: value}]);
+        done(null, []);
+      },
+      getContainer: function (name) {
+        return {
+          inspect: function (done) {
+            return done();
+          }
+        }
+      }
+    };
+    links.resolveLinks(docker, ['a', 'b'], function (err, links) {
+      expect(err).to.be.undefined;
+      expect(links).to.deep.equal(['a:a', 'b:b']);
+      done();
+    });
+  });
+
+  it('resolves links with the com.docker.compose.service label', function (done) {
+    var docker = {
+      listContainers: function (opts, done) {
+        var parts = JSON.parse(opts.filters).label[0].split('=');
+        var label = parts[0];
+        var value = parts[1];
+        if (label === 'com.docker.compose.service') return done(null, [{Id: value}]);
+        done(null, []);
+      },
+      getContainer: function (name) {
+        return {
+          inspect: function (done) {
+            return done();
+          }
+        }
+      }
+    };
+    links.resolveLinks(docker, ['a', 'b'], function (err, links) {
+      expect(err).to.be.undefined;
+      expect(links).to.deep.equal(['a:a', 'b:b']);
+      done();
+    });
+  });
+
+});


### PR DESCRIPTION
This adds a config field that accepts docker link names, similar to the volumes field. In addition to linking by container names/IDs (normal docker behavior), the `com.stridercd.link` and `com.docker.compose.service` label values are checked as well.