### PR TITLE
Allow multiple colons in the image's name

### DIFF
--- a/lib/create-container.js
+++ b/lib/create-container.js
@@ -9,7 +9,14 @@ const inspect = require('util').inspect;
 const stream = require('stream');
 
 function isImageLocally(docker, image, done) {
-  const withoutTag = image.split(':')[0];
+  const imageSplitted = image.split(':');
+  const withoutTag = imageSplitted.reduce((accum, current, index) => {
+    if (index < imageSplitted.length - 1) {
+      return `${accum}:${current}`;
+    } else {
+      return accum;
+    }
+  });
   const fullname = image === withoutTag ? `${image}:latest` : image;
 
   docker.listImages({filter: withoutTag}, function (err, images) {


### PR DESCRIPTION
The actual code does not work if the image's name contains more than a colon. For example, something like `myhost:5000/myimage:latest` does not work.

Fix this issue https://github.com/Strider-CD/strider-docker-runner/issues/44